### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,7 @@ go get -u github.com/moul/advanced-ssh-config/cmd/assh
 Get the latest version using homebrew (Mac OS X):
 
 ```bash
-brew install https://raw.githubusercontent.com/moul/advanced-ssh-config/master/contrib/homebrew/assh.rb --HEAD
-```
-
-or the latest released version:
-
-```bash
-brew install https://raw.githubusercontent.com/moul/advanced-ssh-config/master/contrib/homebrew/assh.rb
+brew install assh
 ```
 
 ---


### PR DESCRIPTION
Just a reminder about the OSX install section in the `README`, seems to be outdated ? 
I saw that `assh` was merged in homebrew (Homebrew/homebrew/pull/48815) and `brew install assh` is now functional.