### PR TITLE
Support multiple string arguments of the same type on `assh wrapper ssh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ With the wrapper, `ssh` will *always* be called with an updated `~/.ssh/config` 
 
 ### master (unreleased)
 
+* Support multiple string arguments of the same type on `assh wrapper ssh` ([#185](https://github.com/moul/advanced-ssh-config/issues/185))
 * Remove the `NoControlMasterMkdir` option, and add the `ControlMasterMkdir` option instead ([#173](https://github.com/moul/advanced-ssh-config/issues/173))
 * Accepting string or slices for list options ([#119](https://github.com/moul/advanced-ssh-config/issues/119))
 * Add new `PubkeyAcceptedKeyTypes` OpenSSH 7+ field ([#175](https://github.com/moul/advanced-ssh-config/issues/175))

--- a/pkg/commands/wrapper.go
+++ b/pkg/commands/wrapper.go
@@ -27,7 +27,7 @@ func cmdWrapper(c *cli.Context) error {
 		}
 	}
 	for _, flag := range config.SSHStringFlags {
-		if val := c.String(flag); val != "" {
+		for _, val := range c.StringSlice(flag) {
 			options = append(options, fmt.Sprintf("-%s", flag))
 			options = append(options, val)
 		}

--- a/pkg/config/ssh_flags.go
+++ b/pkg/config/ssh_flags.go
@@ -13,7 +13,6 @@ var SSHStringFlags = []string{"b", "c", "D", "E", "e", "F", "I", "i", "L", "l", 
 
 func init() {
 	// Populate SSHFlags
-	// FIXME: support slice flags (-O a -O b -O c === []string{"a", "b", "c"}
 	// FIXME: support count flags (-vvv == -v -v -v)
 	// FIXME: support joined bool flags (-it == -i -t)
 	for _, flag := range SSHBoolFlags {
@@ -22,9 +21,9 @@ func init() {
 		})
 	}
 	for _, flag := range SSHStringFlags {
-		SSHFlags = append(SSHFlags, cli.StringFlag{
-			Name:  flag,
-			Value: "",
+		SSHFlags = append(SSHFlags, cli.StringSliceFlag{
+			Name: flag,
+			//Value: "",
 		})
 	}
 }


### PR DESCRIPTION
Fix #185 