### PR TITLE
Loads hosts from `~/.ssh/assh_known_hosts` file when calling `assh config build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ With the wrapper, `ssh` will *always* be called with an updated `~/.ssh/config` 
 * Fix integers output in `assh config list` ([#181](https://github.com/moul/advanced-ssh-config/issues/181))
 * Initial graphviz support ([#32](https://github.com/moul/advanced-ssh-config/issues/32))
 * Remove case-sensitivity for `Inherits` and `Gateways` ([#178](https://github.com/moul/advanced-ssh-config/issues/178))
+* Loads hosts from `~/.ssh/assh_known_hosts` file when calling `assh config build`, can be ignored using `--ignore-known-hosts` ([#178](https://github.com/moul/advanced-ssh-config/issues/178))
 
 [Full commits list](https://github.com/moul/advanced-ssh-config/compare/v2.5.0...master)
 

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -26,6 +26,12 @@ func cmdBuild(c *cli.Context) error {
 		}
 	}
 
+	if !c.Bool("ignore-known-hosts") {
+		if err:= conf.LoadKnownHosts(); err != nil {
+			Logger.Errorf("Failed to load known-hosts file: %v", err)
+		}
+	}
+
 	conf.WriteSSHConfigTo(os.Stdout)
 
 	return nil

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -73,6 +73,10 @@ var Commands = []cli.Command{
 						Name:  "expand, e",
 						Usage: "Expand all fields",
 					},
+					cli.BoolFlag{
+						Name:  "ignore-known-hosts",
+						Usage: "Ignore known-hosts file",
+					},
 				},
 				Action: cmdBuild,
 			},


### PR DESCRIPTION
can be ignored using `--ignore-known-hosts`

Related with #178