### PR TITLE
Initial support of values validation to avoid writing invalid `.ssh/config` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ With the wrapper, `ssh` will *always* be called with an updated `~/.ssh/config` 
 * OpenBSD support ([#182](https://github.com/moul/advanced-ssh-config/issues/182))
 * Improve hostname output in `assh config list` ([#204](https://github.com/moul/advanced-ssh-config/issues/204))
 * Support for inline comments ([#34](https://github.com/moul/advanced-ssh-config/issues/34))
+* Initial support of values validation to avoid writing invalid .ssh/config file ([#92](https://github.com/moul/advanced-ssh-config/issues/92))
 
 [Full commits list](https://github.com/moul/advanced-ssh-config/compare/v2.5.0...master)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1564,3 +1564,26 @@ Host *
 		So(output, ShouldEqual, expected)
 	})
 }
+
+func TestConfig_ValidateSummary(t *testing.T) {
+	Convey("Testing Config.ValidateSummary", t, FailureContinues, func() {
+		// no error
+		config := New()
+		config.Hosts["toto"] = &Host{name: "toto"}
+		err := config.ValidateSummary()
+		So(err, ShouldBeNil)
+
+		// one error
+		config.Hosts["toto"].ControlMaster = "invalid data"
+		err = config.ValidateSummary()
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, `"toto": invalid value for 'ControlMaster': "invalid data"`)
+
+		// multiple errors
+		config.Hosts["toto"].AddressFamily = "invalid data"
+		config.Hosts["tata"] = &Host{name: "tata"}
+		config.Hosts["tata"].AddressFamily = "invalid data"
+		errs := config.Validate()
+		So(len(errs), ShouldEqual, 3)
+	})
+}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -14,7 +14,7 @@ func isDynamicHostname(hostname string) bool {
 
 // BoolVal returns a boolean matching a configuration string
 func BoolVal(input string) bool {
-	input = strings.ToLower(input)
+	input = cleanupValue(input)
 	trueValues := []string{"yes", "ok", "true", "1", "enabled"}
 	for _, val := range trueValues {
 		if val == input {
@@ -22,6 +22,10 @@ func BoolVal(input string) bool {
 		}
 	}
 	return false
+}
+
+func cleanupValue(input string) string {
+	return strings.TrimSpace(strings.ToLower(input))
 }
 
 // stringComment splits comment strings into <1024 char lines

--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -138,6 +138,27 @@ func NewHost(name string) *Host {
 	}
 }
 
+// Validate checks for values errors
+func (h *Host) Validate() []error {
+	errs := []error{}
+
+	switch cleanupValue(h.AddressFamily) {
+	case "", "any", "inet", "inet4", "inet6":
+		break
+	default:
+		errs = append(errs, fmt.Errorf("%q: invalid value for 'AddressFamily': %q", h.name, h.ControlMaster))
+	}
+
+	switch cleanupValue(h.ControlMaster) {
+	case "", "yes", "no", "ask", "auto", "autoask":
+		break
+	default:
+		errs = append(errs, fmt.Errorf("%q: invalid value for 'ControlMaster': %q", h.name, h.ControlMaster))
+	}
+
+	return errs
+}
+
 // String returns the JSON output
 func (h *Host) String() string {
 	s, _ := json.Marshal(h)

--- a/pkg/config/host_test.go
+++ b/pkg/config/host_test.go
@@ -137,6 +137,27 @@ func TestHost_Matches(t *testing.T) {
 	})
 }
 
+func TestHost_Validate(t *testing.T) {
+	Convey("Testing Host.Validate()", t, FailureContinues, func() {
+		host := NewHost("abc")
+
+		errs := host.Validate()
+		So(len(errs), ShouldEqual, 0)
+
+		for _, value := range []string{"yes", "no", "ask", "auto", "autoask", "", "Yes", "YES", "yEs", " yes "} {
+			host.ControlMaster = value
+			errs = host.Validate()
+			So(len(errs), ShouldEqual, 0)
+		}
+
+		for _, value := range []string{"blah blah", "invalid"} {
+			host.ControlMaster = value
+			errs = host.Validate()
+			So(len(errs), ShouldEqual, 1)
+		}
+	})
+}
+
 func TestHost_Options(t *testing.T) {
 	Convey("Testing Host.Options()", t, func() {
 		host := NewHost("abc")


### PR DESCRIPTION
fix #92 