### PR TITLE
This addresses recent build issues on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker:
 
 
 $(BINARIES):	$(SOURCES)
-	$(GO) build -i -v -o $@ ./cmd/$@
+	$(GO) build -ldflags=-s -i -v -o $@ ./cmd/$@
 
 
 .PHONY: test


### PR DESCRIPTION
Go generated binaries on OSX are behaving like this, this is due to a recent OSX update that breaks a few things

```
./assh
Killed: 9
```

This is related to https://github.com/golang/go/issues/19734