### PR TITLE
Features / fixes

### DIFF
--- a/pkg/commands/proxy.go
+++ b/pkg/commands/proxy.go
@@ -178,7 +178,7 @@ func expandSSHTokens(tokenized string, host *config.Host, gateway *config.Host) 
 	result = strings.Replace(result, "%i", strconv.Itoa(os.Geteuid()), -1)
 	result = strings.Replace(result, "%p", host.Port, -1)
 
-	if hostname, err := os.Hostname() ; err == nil {
+	if hostname, err := os.Hostname(); err == nil {
 		result = strings.Replace(result, "%L", hostname, -1)
 	} else {
 		result = strings.Replace(result, "%L", "hostname", -1)
@@ -187,7 +187,7 @@ func expandSSHTokens(tokenized string, host *config.Host, gateway *config.Host) 
 	if host.User != "" {
 		result = strings.Replace(result, "%r", host.User, -1)
 	} else {
-		if userdata, err := user.Current() ; err == nil {
+		if userdata, err := user.Current(); err == nil {
 			result = strings.Replace(result, "%r", userdata.Username, -1)
 		} else {
 			result = strings.Replace(result, "%r", "username", -1)
@@ -198,7 +198,7 @@ func expandSSHTokens(tokenized string, host *config.Host, gateway *config.Host) 
 }
 
 func prepareHostControlPath(host, gateway *config.Host) error {
-	if ! config.BoolVal(host.ControlMasterMkdir) && ("none" == host.ControlPath) {
+	if !config.BoolVal(host.ControlMasterMkdir) && ("none" == host.ControlPath) {
 		return nil
 	}
 
@@ -210,7 +210,7 @@ func prepareHostControlPath(host, gateway *config.Host) error {
 
 func proxy(host *config.Host, conf *config.Config, dryRun bool) error {
 
-	emptygw := config.Host {}
+	emptygw := config.Host{}
 	prepareHostControlPath(host.Clone(), emptygw.Clone())
 
 	if len(host.Gateways) > 0 {

--- a/pkg/commands/proxy.go
+++ b/pkg/commands/proxy.go
@@ -211,13 +211,16 @@ func prepareHostControlPath(host, gateway *config.Host) error {
 func proxy(host *config.Host, conf *config.Config, dryRun bool) error {
 
 	emptygw := config.Host{}
-	prepareHostControlPath(host.Clone(), emptygw.Clone())
+	err := prepareHostControlPath(host.Clone(), emptygw.Clone())
+	if err != nil {
+		return err
+	}
 
 	if len(host.Gateways) > 0 {
 		logger.Logger.Debugf("Trying gateways: %s", host.Gateways)
 		for _, gateway := range host.Gateways {
 			if gateway == "direct" {
-				err := proxyDirect(host, dryRun)
+				err = proxyDirect(host, dryRun)
 				if err != nil {
 					logger.Logger.Errorf("Failed to use 'direct' connection: %v", err)
 				}
@@ -225,7 +228,7 @@ func proxy(host *config.Host, conf *config.Config, dryRun bool) error {
 				hostCopy := host.Clone()
 				gatewayHost := conf.GetGatewaySafe(gateway)
 
-				err := prepareHostControlPath(hostCopy, gatewayHost)
+				err = prepareHostControlPath(hostCopy, gatewayHost)
 				if err != nil {
 					return err
 				}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -431,7 +431,8 @@ func (c *Config) SaveSSHConfig() error {
 	}
 	defer func() {
 		if err := os.Remove(tmpFile.Name()); err != nil {
-			panic(err)
+			logger.Logger.Warnf("Unable to remove tempfile: %s", tmpFile.Name())
+			// panic(err)
 		}
 	}()
 


### PR DESCRIPTION
- Support SSH tokens and ~ expansion in ControlPaths
- Ensure ControlPath directories are properly created when using syntax such as "ssh host1/host2"
- Change panic() to a warning statement when removing the temporary file.  Since delete is deferred,
  the config file should have already been renamed and would no longer exist.