### PR TITLE
Add return to proxyDirect to avoid double-connection.

### DIFF
--- a/pkg/commands/proxy.go
+++ b/pkg/commands/proxy.go
@@ -223,6 +223,8 @@ func proxy(host *config.Host, conf *config.Config, dryRun bool) error {
 				err = proxyDirect(host, dryRun)
 				if err != nil {
 					logger.Logger.Errorf("Failed to use 'direct' connection: %v", err)
+				} else {
+					return nil
 				}
 			} else {
 				hostCopy := host.Clone()

--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -186,11 +186,11 @@ func (h *Host) Prototype() string {
 			hostname = h.name
 		}
 	}
-
+//REX: disabling for now, this *CAN* be correct, but does it consider defaults?
 	port := h.Port
-	if port == "" {
-		port = "22"
-	}
+	//if port == "" {
+	//	port = "22"
+	//}
 	return fmt.Sprintf("%s@%s:%s", username, hostname, port)
 }
 
@@ -1074,8 +1074,9 @@ func (h *Host) ApplyDefaults(defaults *Host) {
 	h.inputName = utils.ExpandField(h.inputName)
 
 	// Extra defaults
+//REX: why does this have special treatment?
 	if h.Port == "" {
-		h.Port = "22"
+		h.Port = defaults.Port
 	}
 }
 


### PR DESCRIPTION
This is to address issue #263 which seemed to only apply to cases where one of the gateway options was direct. Non-direct gateways worked properly since the return if err is nil was already present.