### PR TITLE
fix: fix ConnectHookArgs string conversion in hooks (fixes #262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ defaults:
 
     OnConnect:
       # Log internal information to a file
-      - 'exec echo {{.}} | jq . >> ~/.ssh/last_connected_host.txt'
+      - exec printf '{{.}}' | jq . >> ~/.ssh/last_connected_host.txt
 
       # Alert me with a Desktop notification
       - notify New SSH connection to {{.Host.Prototype}} at {{.Stats.ConnectedAt}}


### PR DESCRIPTION
Stats and Error fields of the ConnectHookArgs struct were not being converted to strings correctly, causing errors when using {{.}} in hooks. Stats would incorrectly print as its pointer value, Error would print as "\<nil>".

Changed README.md to use printf when printing {{.}} because echo discards quote marks in the output (and enclosing {{.}} in single quotes isn't possible).

Added the appropriate String() methods for ConnectionStats and ConnectHookArgs so {{.}} and {{.Stats}} output well-formed JSON.

Converted Error to a string to allow it to be marshaled to JSON correctly.

Fixes #262 